### PR TITLE
Remove react-intl-loader as a dependency

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -61,7 +61,6 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-intl": "^2.3.0",
-        "react-intl-loader": "^1.0.2",
         "react-redux": "^7.1.0",
         "redux": "^4.0.1",
         "redux-devtools-extension": "^2.13.9",
@@ -19827,54 +19826,6 @@
       "peerDependencies": {
         "prop-types": "^15.5.4",
         "react": "^0.14.9 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/react-intl-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-intl-loader/-/react-intl-loader-1.0.2.tgz",
-      "integrity": "sha512-kuX8mpvuiAbxjFdaj/6fzfNvmGkxTwShkF/ZGCZ02zlV1JVR61nLcUgunFGiDsBxTjE9b/X1DvDyWWQFBvMchg==",
-      "dependencies": {
-        "loader-utils": "^0.2.14"
-      },
-      "peerDependencies": {
-        "intl": "^1.1.0",
-        "intl-locales-supported": "^1.0.0",
-        "react-intl": "^2.0.1"
-      }
-    },
-    "node_modules/react-intl-loader/node_modules/big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/react-intl-loader/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/react-intl-loader/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/react-intl-loader/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
       }
     },
     "node_modules/react-is": {

--- a/application/package.json
+++ b/application/package.json
@@ -65,7 +65,6 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-intl": "^2.3.0",
-    "react-intl-loader": "^1.0.2",
     "react-redux": "^7.1.0",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.9",


### PR DESCRIPTION
`react-intl-loader` includes a security vulnurability (via it's dependency `"loader-utils": "^0.2.14"`), but it is no longer used in the codebase. I removed the code here but forgot to remove it as a dependency: https://github.com/mxenabled/universal-connect-widget/pull/18