### PR TITLE
Read supports_oauth variable from MX API

### DIFF
--- a/application/server/providers/mx.ts
+++ b/application/server/providers/mx.ts
@@ -30,6 +30,7 @@ function fromMxInstitution(ins: InstitutionResponse, provider: string): Institut
     id: ins.code!,
     logo_url: ins.medium_logo_url || ins.small_logo_url!,
     name: ins.name!,
+    oauth: ins.supports_oauth!,
     url: ins.url!,
     provider,
   };


### PR DESCRIPTION
When selecting an oauth institution, oauth was not working because the `supports_oauth` variable was not being read from the MX API.

#### Testing
1 - Select an oauth instution for testing (eg Capital One)
2 - Change your preferences to use MX for Capital One
3 - Run the widget, select Capital One, and verify that the oauth screen appears