### PR TITLE
update guide to use ucp hosted login service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Verifiable Credentials are being embraced by regulators because they allow users
 
 ## Get started
 
-- For a quick view check out [this demo site](https://demo.sophtron.com/loader.html?env=https://universalwidget.sophtron-prod.com)
+- For a quick view check out [this demo site](https://ucp-demo.sophtron-prod.com/loader.html?env=https://ucp-widget.sophtron-prod.com)
 - For examples on how to integrate with and embed an hosted widget, please refer to [example/README.md](example/README.md)
 - For development and deployment, please refer to [application/README.md](application/README.md)
 - Usage documentation [openapi](openapi/)

--- a/application/README.md
+++ b/application/README.md
@@ -18,7 +18,7 @@
   6. Start the API server by running `npm run server` in `/application`. At this stage, the API server is running and the widget is available at `http://localhost:8080`.
 
   *Please remember that secrets are passed through environment variables instead of hardcoded in the js file.*
-  DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
+  DO NOT put any credentials in any of the js files. If you do so, it could accidentally get committed and leaked to public.
   USE `.env` FILE
 
   *UCP credentials are required for authentication and secret exchange, storage (redis-like session cache) and analytics services.*

--- a/application/README.md
+++ b/application/README.md
@@ -36,7 +36,7 @@
   5. Open `http://localhost:8088/loader.html?env=http://localhost:8080` in a web browser.
 
 *Please use `.env` to provide the api secrets using the keys in `config.js` as the variable names.*
-DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
+DO NOT put any credentials in any of the js files. If you do so, it could accidentally get committed and leaked to public.
 USE `.env` FILE
 
 *A hosted example can be found [here](https://ucp-demo.sophtron-prod.com/loader.html?env=https://ucp-widget.sophtron-prod.com).*

--- a/application/README.md
+++ b/application/README.md
@@ -37,7 +37,7 @@
 
 *Please use `.env` to provide the api secrets using the keys in `config.js` as the variable names.*
 DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
-USE `.evn` FILE
+USE `.env` FILE
 
 *A hosted example can be found [here](https://ucp-demo.sophtron-prod.com/loader.html?env=https://ucp-widget.sophtron-prod.com).*
 

--- a/application/README.md
+++ b/application/README.md
@@ -39,7 +39,7 @@
 DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
 USE `.evn` FILE
 
-*A hosted example can be found [here](https://demo.sophtron.com/loader.html?env=https://universalwidget.sophtron-prod.com).*
+*A hosted example can be found [here](https://ucp-demo.sophtron-prod.com/loader.html?env=https://ucp-widget.sophtron-prod.com).*
 
 ## List of banks to test with 
 - Sophtron: Sophtron Bank

--- a/application/README.md
+++ b/application/README.md
@@ -1,18 +1,7 @@
 # Quick How-to
 
-## FIRST: Create local config files
-
-These files will not be committed to the repo, and are only used for local development
-
-Copy `/example/application/config.default.js` into `/example/application/config.js`:
-
-```cp /example/application/config.default.js /example/application/config.js```
-
-Copy `/application/server/config.default.js` into `/application/server/config.js`:
-
-```cp /application/server/config.default.js /application/server/config.js```
-
-Note: *The two config files that will result from this step are already included in the `.gitignore` file*
+## FIRST: Get familia with [dotenv](https://www.npmjs.com/package/dotenv)
+- Create your config file `/application/.env` `/example/application/.env`
 
 ## SECOND: There are 3 services to start to get a widget demo running locally.
 ### The Dev server
@@ -22,14 +11,17 @@ Note: *The two config files that will result from this step are already included
 
 ### The API server
   1. Run `npm run keys` in `/application` to generate a new set of `key` and `IV` values.
-  2. Fill in the `CryptoKey` and `CryptoIv` in your newly created [application/server/config.js](server/config.js) file with the generated `key` and `IV`.
-  3. Sign up with Sophtron [here](https://sophtron.com/account/register).
-  4. Fill in the `SophtronClientId` and `SophtronClientSecret` in the [application/server/config.js](server/config.js) file with the values provided by Sophtron.
-  5. Start the API server by running `npm run server` in `/application`. At this stage, the API server is running and the widget is available at `http://localhost:8080`.
+  2. Fill in the `CryptoKey` and `CryptoIv` in your newly created `application/.env` file with the generated `key` and `IV`.
+  3. Sign up a UCP client account: [here](https://ucp-login.sophtron-prod.com/) (the `Click here to login` link navigates to the aws hosted login page where sign up option is available).
+  4. Generate and view your client secrets once registered and logged in
+  5. Fill in the `UcpAuthClientId`, `UcpAuthClientSecret` and `UcpAuthEncryptionKey` in the `application/.env` file with the values provided by login page.
+  6. Start the API server by running `npm run server` in `/application`. At this stage, the API server is running and the widget is available at `http://localhost:8080`.
 
   *Please remember that secrets are passed through environment variables instead of hardcoded in the js file.*
+  DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
+  USE `.evn` FILE
 
-  *Sophtron credentials are required for authentication and secret exchange, storage (redis-like session cache) and analytics services.*
+  *UCP credentials are required for authentication and secret exchange, storage (redis-like session cache) and analytics services.*
   
   *The `CryptoKey` and `CryptoIv` values are for encrypting the session token in order to not rely on cookies. They must be shared across server instances if there are multiple instances.*
 
@@ -38,12 +30,14 @@ Note: *The two config files that will result from this step are already included
 *To get a working demo locally, you need to act as a client (who embeds the widget within their own domain). An [example demo website](../example/README.md) is provided to demonstrate this.*
 
   1. Acquire credentials for one of the supported aggregators (currently MX or Sophtron). To sign up with MX, go [here](https://dashboard.mx.com/sign_up).
-  2. Fill in the relevant credentials in [example/application/config.js](../example/application/config.js) (e.g., if you want to see `mx bank` working in the widget, `MxClientId` and `MxApiSecret` must be provided).
-  3. Fill in the `SophtronApiUserId` and `SophtronApiUserSecret` in the [example/application/config.js](../example/application/config.js) file with the values provided by Sophtron (the same values used in step 4 for the 'The API server' section).
+  2. Fill in the relevant credentials in `example/application/.env` file by following config options in [example/application/config.js](../example/application/config.js) (e.g., if you want to see `mx bank` working in the widget, `MxClientId` and `MxApiSecret` must be provided).
+  3. Fill in the `UcpClientId`, `UcpClientSecret` and `UcpEncryptionKey` in the `example/application/.env` file with the values provided by login page (the same values used in step 5 for the 'The API server' section).
   4. Run `npm ci` and `npm run start` in `example/application` folder to run the demo website.
   5. Open `http://localhost:8088/loader.html?env=http://localhost:8080` in a web browser.
 
-*Please use envrionment variables to provide the api secrets using the keys in `config.js` as the variable names.*
+*Please use `.env` to provide the api secrets using the keys in `config.js` as the variable names.*
+DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
+USE `.evn` FILE
 
 *A hosted example can be found [here](https://demo.sophtron.com/loader.html?env=https://universalwidget.sophtron-prod.com).*
 

--- a/application/README.md
+++ b/application/README.md
@@ -19,7 +19,7 @@
 
   *Please remember that secrets are passed through environment variables instead of hardcoded in the js file.*
   DO NOT put any credentials in any of the js files. this way it will get accidentially committed and leaked to public
-  USE `.evn` FILE
+  USE `.env` FILE
 
   *UCP credentials are required for authentication and secret exchange, storage (redis-like session cache) and analytics services.*
   

--- a/application/README.md
+++ b/application/README.md
@@ -1,6 +1,6 @@
 # Quick How-to
 
-## FIRST: Get familia with [dotenv](https://www.npmjs.com/package/dotenv)
+## FIRST: Get familiar with [dotenv](https://www.npmjs.com/package/dotenv)
 - Create your config file `/application/.env` `/example/application/.env`
 
 ## SECOND: There are 3 services to start to get a widget demo running locally.

--- a/application/server/config.js
+++ b/application/server/config.js
@@ -35,7 +35,7 @@ const config = {
 
   UcpAuthClientId: '',
   UcpAuthClientSecret: '',
-  UcpEncryptionKey: ''
+  UcpAuthEncryptionKey: ''
 
 };
 


### PR DESCRIPTION
The required components  `ucp-login` `ucp-analytics` and `unifield-search`  are now hosted in UCP account and sophtron hard dependency is now removed from universal vcs. 

This readme change points credentials process to the new-but-temporary hosted ucp-login page, currently using sophtron-prod.com dns while waiting for access to UCP dns. 

The last merged PR reverted the default config method and added [DotEnv](https://www.npmjs.com/package/dotenv)  as this is the more common way how js handles local config, also is deployment-friendly 

