### PR TITLE
Remove AI-injected code

### DIFF
--- a/application/config-overrides.js
+++ b/application/config-overrides.js
@@ -46,12 +46,6 @@ module.exports = override(
   function override(config) {
     config.resolve = {
       ...config.resolve,
-      paths: (paths, env) => {
-        paths.testPaths = path.resolve(__dirname, 'tests');
-        paths.appIndexJs = path.resolve(__dirname, 'client/index.jsx');
-        paths.appSrc = path.resolve(__dirname, 'client');
-        return paths;
-      },
       alias: {
         ...config.alias,
         'services': path.resolve(__dirname, '/server/connect'),


### PR DESCRIPTION
The override config had some code I do not recognize, and which broke the widget build. I believe I may have inadvertently added it with the AI code-completion plugin that I use. Removed it, and the build is working again.